### PR TITLE
Add header files and types

### DIFF
--- a/inc/CppWinRTIncludes.h
+++ b/inc/CppWinRTIncludes.h
@@ -7,22 +7,7 @@
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
 
-#ifndef USE_WINUI3
-
-#include <winrt/Windows.System.h>
-#include <winrt/Windows.UI.Xaml.h>
-
-#define XAML_CPPWINRT_NAMESPACE winrt::Windows::UI::Xaml
-namespace xaml = winrt::Windows::UI::Xaml;
-namespace comp = winrt::Windows::UI::Composition;
-namespace ui = winrt::Windows::UI;
-namespace winrt {
-    namespace system = winrt::Windows::System;
-    using ColorHelper = winrt::Windows::UI::ColorHelper;
-    using Colors = winrt::Windows::UI::Colors;
-} // namespace winrt
-
-#else
+#ifdef USE_WINUI3
 
 #include <winrt/Microsoft.System.h>
 #include <winrt/Microsoft.UI.Xaml.h>
@@ -42,6 +27,21 @@ namespace winrt::Microsoft::UI::Xaml {
     using IUIElement9 = UIElement;
     using IUIElement10 = UIElement;
 } // namespace winrt::Microsoft::UI::Xaml
+
+#else
+
+#include <winrt/Windows.System.h>
+#include <winrt/Windows.UI.Xaml.h>
+
+#define XAML_CPPWINRT_NAMESPACE winrt::Windows::UI::Xaml
+namespace xaml = winrt::Windows::UI::Xaml;
+namespace comp = winrt::Windows::UI::Composition;
+namespace ui = winrt::Windows::UI;
+namespace winrt {
+    namespace system = winrt::Windows::System;
+    using ColorHelper = winrt::Windows::UI::ColorHelper;
+    using Colors = winrt::Windows::UI::Colors;
+} // namespace winrt
 
 #endif // USE_WINUI3
 

--- a/inc/CppWinRTIncludes.h
+++ b/inc/CppWinRTIncludes.h
@@ -17,10 +17,11 @@ namespace xaml = winrt::Windows::UI::Xaml;
 namespace comp = winrt::Windows::UI::Composition;
 namespace ui = winrt::Windows::UI;
 namespace winrt {
-namespace system = winrt::Windows::System;
-using ColorHelper = winrt::Windows::UI::ColorHelper;
-using Colors = winrt::Windows::UI::Colors;
+    namespace system = winrt::Windows::System;
+    using ColorHelper = winrt::Windows::UI::ColorHelper;
+    using Colors = winrt::Windows::UI::Colors;
 } // namespace winrt
+
 #else
 
 #include <winrt/Microsoft.System.h>
@@ -31,23 +32,23 @@ namespace xaml = winrt::Microsoft::UI::Xaml;
 namespace comp = winrt::Microsoft::UI::Composition;
 namespace ui = winrt::Microsoft::UI;
 namespace winrt {
-namespace system = winrt::Microsoft::System;
-using ColorHelper = winrt::Microsoft::UI::ColorHelper;
-using Colors = winrt::Microsoft::UI::Colors;
+    namespace system = winrt::Microsoft::System;
+    using ColorHelper = winrt::Microsoft::UI::ColorHelper;
+    using Colors = winrt::Microsoft::UI::Colors;
 } // namespace winrt
 
 namespace winrt::Microsoft::UI::Xaml {
-using IUIElement7 = UIElement;
-using IUIElement9 = UIElement;
-using IUIElement10 = UIElement;
+    using IUIElement7 = UIElement;
+    using IUIElement9 = UIElement;
+    using IUIElement10 = UIElement;
 } // namespace winrt::Microsoft::UI::Xaml
 
-#endif
+#endif // USE_WINUI3
 
 namespace winrt {
-using namespace Windows::UI::Core;
-using namespace Windows::Foundation;
-using namespace Windows::Foundation::Collections;
+    using namespace Windows::UI::Core;
+    using namespace Windows::Foundation;
+    using namespace Windows::Foundation::Collections;
 } // namespace winrt
 
 #define _QUOTE(x) L#x

--- a/inc/NamespaceRedirect.h
+++ b/inc/NamespaceRedirect.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifndef USE_WINUI3
-#define XAML_NAMESPACE Windows.UI.Xaml
-#else
+#ifdef USE_WINUI3
 #define XAML_NAMESPACE Microsoft.UI.Xaml
+#else
+#define XAML_NAMESPACE Windows.UI.Xaml
 #endif

--- a/inc/UI.Text.h
+++ b/inc/UI.Text.h
@@ -9,7 +9,7 @@
 #include <winrt/Microsoft.UI.Text.h>
 namespace text = winrt::Microsoft::UI::Text;
 namespace winrt::Microsoft::UI::Text {
-using FontStyle = winrt::Windows::UI::Text::FontStyle;
+    using FontStyle = winrt::Windows::UI::Text::FontStyle;
 }
 #else
 namespace text = winrt::Windows::UI::Text;

--- a/inc/UI.Xaml.Automation.Provider.h
+++ b/inc/UI.Xaml.Automation.Provider.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef USE_WINUI3
+#include <winrt/Microsoft.UI.Xaml.Automation.Provider.h>
+#else
+#include <winrt/Windows.UI.Xaml.Automation.Provider.h>
+#endif //  USE_WINUI3

--- a/inc/UI.Xaml.Automation.Text.h
+++ b/inc/UI.Xaml.Automation.Text.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef USE_WINUI3
+#include <winrt/Microsoft.UI.Xaml.Automation.Text.h>
+#else
+#include <winrt/Windows.UI.Xaml.Automation.Text.h>
+#endif //  USE_WINUI3

--- a/inc/UI.Xaml.Controls.h
+++ b/inc/UI.Xaml.Controls.h
@@ -8,6 +8,7 @@
 namespace winrt::Microsoft::UI::Xaml::Controls {
     using IPasswordBox4 = ::winrt::Microsoft::UI::Xaml::Controls::IPasswordBox;
     using ITextBox6 = ::winrt::Microsoft::UI::Xaml::Controls::ITextBox;
+    using IFlyoutButton = ::winrt::Microsoft::UI::Xaml::Controls::IButton;
 }; // namespace winrt::Microsoft::UI::Xaml::Controls
 #else
 #include <winrt/Windows.UI.Xaml.Controls.h>

--- a/inc/UI.Xaml.Controls.h
+++ b/inc/UI.Xaml.Controls.h
@@ -6,8 +6,8 @@
 #ifdef USE_WINUI3
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 namespace winrt::Microsoft::UI::Xaml::Controls {
-using IPasswordBox4 = ::winrt::Microsoft::UI::Xaml::Controls::IPasswordBox;
-using ITextBox6 = ::winrt::Microsoft::UI::Xaml::Controls::ITextBox;
+    using IPasswordBox4 = ::winrt::Microsoft::UI::Xaml::Controls::IPasswordBox;
+    using ITextBox6 = ::winrt::Microsoft::UI::Xaml::Controls::ITextBox;
 }; // namespace winrt::Microsoft::UI::Xaml::Controls
 #else
 #include <winrt/Windows.UI.Xaml.Controls.h>

--- a/inc/UI.Xaml.Data.h
+++ b/inc/UI.Xaml.Data.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef USE_WINUI3
+#include <winrt/Microsoft.UI.Xaml.Data.h>
+#else
+#include <winrt/Windows.UI.Xaml.Data.h>
+#endif //  USE_WINUI3

--- a/inc/UI.Xaml.Media.Animation.h
+++ b/inc/UI.Xaml.Media.Animation.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef USE_WINUI3
+#include <winrt/Microsoft.UI.Xaml.Media.Animation.h>
+#else
+#include <winrt/Windows.UI.Xaml.Media.Animation.h>
+#endif //  USE_WINUI3

--- a/inc/UI.Xaml.Printing.h
+++ b/inc/UI.Xaml.Printing.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef USE_WINUI3
+#include <winrt/Microsoft.UI.Xaml.Printing.h>
+#else
+#include <winrt/Windows.UI.Xaml.Printing.h>
+#endif //  USE_WINUI3

--- a/inc/UI.Xaml.Resources.h
+++ b/inc/UI.Xaml.Resources.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef USE_WINUI3
+#include <winrt/Microsoft.UI.Xaml.Resources.h>
+#else
+#include <winrt/Windows.UI.Xaml.Resources.h>
+#endif //  USE_WINUI3


### PR DESCRIPTION
This change standardizes on using `#ifdef USE_WINUI3`, rather than a combination of that and `#ifndef`. It adds an `IFlyoutButton` type for the Microsoft.UI.Xaml namespace. It also adds a few additional headers that are common to the Microsoft.UI.Xaml and Windows.UI.Xaml namespaces.